### PR TITLE
Add compile flags for MacOS.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "link-arg=-Wl,-rpath,/Applications/Xcode.app/Contents/Frameworks"]


### PR DESCRIPTION
Adds a configuration so cargo can find libclang.dylib. Run "cargo build" to compile on MacOS. Tested successfully on 10.14.6. Requires Xcode to be installed (may also require installation of Xcode command line tools).