### PR TITLE
HTTP request timeout should have env variable option

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,9 @@ Output Filename Suffix: rjcal-rad
  * msl_mcam_drcx
  * msl_mcam_drxx
 
+## Data Retrieval
+By default, HTTP requests are limited to a default of 60 seconds before timeout occurs. If another value is needed, set the environment variable `MRU_HTTP_TIMEOUT` to a positive whole-number integer in number of seconds. 
+
 ## Calibration
 Images posted to the NASA raw image pages are derived from what are known as Experimental Data Records (EDR). Not having gone through the ground pipelines, these images are raw and unprocessed. Further, the images have had various levels of compression applied to make them easier to serve on a website. 
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -4,6 +4,10 @@ pub const DEFAULT_BLUE_WEIGHT: f32 = 1.0;
 
 pub const OUTPUT_FILENAME_APPEND: &str = "rjcal";
 
+pub mod env {
+    pub const HTTP_TIMEOUT_VAR: &str = "MRU_HTTP_TIMEOUT";
+}
+
 pub mod url {
     pub const MSL_RAW_WEBSERVICE_URL: &str = "https://mars.nasa.gov/api/v1/raw_image_items/";
     pub const MSL_LATEST_WEBSERVICE_URL: &str =

--- a/src/httpfetch.rs
+++ b/src/httpfetch.rs
@@ -188,3 +188,28 @@ pub async fn simple_fetch_text_monitored<F: Fn(u64, u64, f32)>(uri: &str, f: F) 
         Err(why) => Err(why.into()),
     }
 }
+
+#[test]
+fn test_get_timeout_seconds() {
+    env::remove_var("MRU_HTTP_TIMEOUT");
+
+    assert_eq!(get_timeout_seconds().unwrap(), DEFAULT_TIMEOUT);
+
+    env::set_var("MRU_HTTP_TIMEOUT", "FOO");
+    assert_eq!(get_timeout_seconds().unwrap(), DEFAULT_TIMEOUT);
+
+    env::set_var("MRU_HTTP_TIMEOUT", "-34");
+    assert_eq!(get_timeout_seconds().unwrap(), DEFAULT_TIMEOUT);
+
+    env::set_var("MRU_HTTP_TIMEOUT", "34.45");
+    assert_eq!(get_timeout_seconds().unwrap(), DEFAULT_TIMEOUT);
+
+    env::set_var("MRU_HTTP_TIMEOUT", "-34.45");
+    assert_eq!(get_timeout_seconds().unwrap(), DEFAULT_TIMEOUT);
+
+    env::set_var("MRU_HTTP_TIMEOUT", "120");
+    assert_eq!(get_timeout_seconds().unwrap(), 120);
+
+    env::set_var("MRU_HTTP_TIMEOUT", "120_u64");
+    assert_eq!(get_timeout_seconds().unwrap(), DEFAULT_TIMEOUT);
+}

--- a/src/httpfetch.rs
+++ b/src/httpfetch.rs
@@ -4,6 +4,7 @@
 use reqwest::Client;
 use reqwest::Url;
 use std::cmp::min;
+use std::env;
 use std::time::Duration;
 
 // Convention is to seperate your stuff from stuff another viewer is likely to know, there's a new
@@ -12,6 +13,10 @@ use anyhow::anyhow;
 use anyhow::Result; // you'll find a lot, if not most these days of CLI apps or bins in general are running anyhow::Results in their return types.
 use futures_util::StreamExt;
 use std::string::String;
+
+use crate::constants;
+use crate::util::string_is_valid_u64;
+
 pub struct HttpFetcher {
     //uri: String, // Use reqwest::Url.
     client: Client,
@@ -21,6 +26,19 @@ pub struct HttpFetcher {
 }
 
 const DEFAULT_TIMEOUT: u64 = 60;
+
+fn get_timeout_seconds() -> Result<u64> {
+    if let Ok(v) = env::var(constants::env::HTTP_TIMEOUT_VAR) {
+        if string_is_valid_u64(v.as_str()) {
+            v.parse::<u64>()
+                .or(Err(anyhow!("Failed to parse \"{:?}\" to u64", v)))
+        } else {
+            Ok(DEFAULT_TIMEOUT)
+        }
+    } else {
+        Ok(DEFAULT_TIMEOUT)
+    }
+}
 
 #[derive(Debug)]
 pub struct SimpleHttpResponse {
@@ -36,17 +54,25 @@ pub struct SimpleHttpResponseString {
 // This is rather hacky and minimal.
 impl HttpFetcher {
     pub fn new(uri: &str) -> Result<HttpFetcher> {
-        Ok(HttpFetcher {
-            uri: uri.parse::<Url>()?,
-            timeout: Duration::from_secs(DEFAULT_TIMEOUT),
-            numparams: 0,
-            client: Client::builder()
-                .timeout(Duration::from_secs(DEFAULT_TIMEOUT))
-                .build()?,
-        })
+        match get_timeout_seconds() {
+            Ok(timeout_seconds) => {
+                info!("Using HTTP Timeoout (seconds): {}", timeout_seconds);
+
+                Ok(HttpFetcher {
+                    uri: uri.parse::<Url>()?,
+                    timeout: Duration::from_secs(timeout_seconds),
+                    numparams: 0,
+                    client: Client::builder()
+                        .timeout(Duration::from_secs(timeout_seconds))
+                        .build()?,
+                })
+            }
+            Err(why) => Err(why),
+        }
     }
 
     pub fn set_timeout(&mut self, seconds: u64) {
+        info!("Setting http timeout to custom {} seconds", seconds);
         self.timeout = Duration::from_secs(seconds);
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -27,6 +27,10 @@ pub fn string_is_valid_f64(s: &str) -> bool {
     sciutil::string_is_valid_f64(s)
 }
 
+pub fn string_is_valid_u64(s: &str) -> bool {
+    sciutil::string_is_valid_num::<u64>(s)
+}
+
 pub fn string_is_valid_f32(s: &str) -> bool {
     sciutil::string_is_valid_f32(s)
 }


### PR DESCRIPTION
Currently, the http timeout defaults to 60 seconds via the hardcoded const httpfetch::DEFAULT_TIMEOUT. Instead, use option_env!("MRU_HTTP_TIMEOUT") to check whether an environment variable exists. This variable should be a positive whole number and in seconds.


Solution: Added environment variable `MRU_HTTP_TIMEOUT` in function `get_timeout_seconds()`. This function will attempt to parse the environment variable into a `u64`. If the variable is not found or is not a proper integer, it will return the default stored in `httpfetch::DEFAULT_TIMEOUT`. If there is a parse error, it will return that error. The timeout value is applied in `HttpFetcher::new()`, and can be overridden programmatically using the existing `HttpFetcher::set_timeout(u64)`